### PR TITLE
Fix typo in 2014/testing/4 (swapped arguments)

### DIFF
--- a/2014/testing/test1/string_test.go
+++ b/2014/testing/test1/string_test.go
@@ -9,6 +9,6 @@ func TestIndex(t *testing.T) {
 	const s, sep, want = "chicken", "ken", 4
 	got := strings.Index(s, sep)
 	if got != want {
-		t.Errorf("Index(%q,%q) = %v; want %v", s, sep, want, got)
+		t.Errorf("Index(%q,%q) = %v; want %v", s, sep, got, want)
 	}
 }


### PR DESCRIPTION
Resolves golang/go#9213
